### PR TITLE
feat(dart_package): `report_on` and `analyze_directories` inputs

### DIFF
--- a/.github/workflows/dart_package.yml
+++ b/.github/workflows/dart_package.yml
@@ -23,6 +23,14 @@ on:
         required: false
         type: number
         default: 100
+      analyze_on:
+        required: false
+        type: string
+        default: "lib test"
+      report_on:
+        required: false
+        type: string
+        default: "lib"
 
 jobs:
   build:
@@ -48,12 +56,12 @@ jobs:
         run: dart format --set-exit-if-changed .
 
       - name: 🕵️ Analyze
-        run: dart analyze --fatal-infos --fatal-warnings lib test
+        run: dart analyze --fatal-infos --fatal-warnings ${{inputs.analyze_on}}
 
       - name: 🧪 Run Tests
         run: |
           dart pub global activate coverage 1.2.0
-          dart test -j ${{inputs.concurrency}} --coverage=coverage && dart pub global run coverage:format_coverage --lcov --in=coverage --out=coverage/lcov.info --packages=.packages --report-on=lib
+          dart test -j ${{inputs.concurrency}} --coverage=coverage && dart pub global run coverage:format_coverage --lcov --in=coverage --out=coverage/lcov.info --packages=.packages --report-on=${{inputs.report_on}}
 
       - name: 📊 Check Code Coverage
         uses: VeryGoodOpenSource/very_good_coverage@v1

--- a/.github/workflows/dart_package.yml
+++ b/.github/workflows/dart_package.yml
@@ -23,7 +23,7 @@ on:
         required: false
         type: number
         default: 100
-      analyze_on:
+      analyze_directories:
         required: false
         type: string
         default: "lib test"
@@ -56,7 +56,7 @@ jobs:
         run: dart format --set-exit-if-changed .
 
       - name: 🕵️ Analyze
-        run: dart analyze --fatal-infos --fatal-warnings ${{inputs.analyze_on}}
+        run: dart analyze --fatal-infos --fatal-warnings ${{inputs.analyze_directories}}
 
       - name: 🧪 Run Tests
         run: |

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The Dart package workflow consists of the following steps:
 
 **Default** `"."`
 
-#### `analyze_on`
+#### `analyze_directories`
 
 **Optional** A space seperated list of folders that should be analyzed.
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,18 @@ The Dart package workflow consists of the following steps:
 
 **Default** `"."`
 
+#### `analyze_on`
+
+**Optional** A space seperated list of folders that should be analyzed.
+
+**Default** `"lib test"`
+
+#### `report_on`
+
+**Optional** A comma seperated list of folders that should be checked in code coverage.
+
+**Default** `"lib"`
+
 ### Example Usage
 
 ```yaml


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Closes #51 

Adds two parameters to the Dart workflow: `analyze_on` and `report_on`.

- `analyze_directories`: A list of folders that should be analyzed by the dart analyzer step
- `report_on`: A list of folders that should be reported on in the check code coverage step

### Usefulness

This change is very helpful for things like a [dart_frog](https://github.com/VeryGoodOpenSource/dart_frog) project where you would like to check code coverage and analyzer in the `routes` folder, not just lib and/or test.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

Thanks for everything you do VGV 💙 