### PR TITLE
feat: Add `format_directories` option

### DIFF
--- a/.github/workflows/dart_package.yml
+++ b/.github/workflows/dart_package.yml
@@ -19,6 +19,10 @@ on:
         required: false
         type: string
         default: "stable"
+      format_directories:
+        required: false
+        type: string
+        default: "."
       min_coverage:
         required: false
         type: number
@@ -73,7 +77,7 @@ jobs:
         run: ${{inputs.setup}}
 
       - name: ✨ Check Formatting
-        run: dart format --set-exit-if-changed .
+        run: dart format --set-exit-if-changed ${{inputs.format_directories}}
 
       - name: 🕵️ Analyze
         run: dart analyze --fatal-infos --fatal-warnings ${{inputs.analyze_directories}}

--- a/.github/workflows/flutter_package.yml
+++ b/.github/workflows/flutter_package.yml
@@ -23,6 +23,10 @@ on:
         required: false
         type: string
         default: ""
+      format_directories:
+        required: false
+        type: string
+        default: "lib test"
       min_coverage:
         required: false
         type: number
@@ -83,7 +87,7 @@ jobs:
         run: ${{inputs.setup}}
 
       - name: ✨ Check Formatting
-        run: dart format --set-exit-if-changed lib test
+        run: dart format --set-exit-if-changed ${{inputs.format_directories}}
 
       - name: 🕵️ Analyze
         run: flutter analyze ${{inputs.analyze_directories}}

--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ The Dart package workflow consists of the following steps:
 
 **Default** `"lib test"`
 
+#### `format_directories`
+
+**Optional** A space separated list of folders that should be formatted.
+
+**Default** `"."`
+
 #### `check_ignore`
 
 **Optional** Allows ignoring lines from [coverage][coverage].
@@ -156,6 +162,12 @@ The Flutter package workflow consists of the following steps:
 #### `analyze_directories`
 
 **Optional** A space separated list of folders that should be analyzed.
+
+**Default** `"lib test"`
+
+#### `format_directories`
+
+**Optional** A space separated list of folders that should be formatted.
 
 **Default** `"lib test"`
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

Analogous to the `analyze_directories` option that already exists. Allows the user to configure for which directories wants to check formatting. Useful for excluding generated code, for example.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
