### PR TITLE
docs: included dart_package.md missing "coverage" URL

### DIFF
--- a/site/docs/workflows/dart_package.md
+++ b/site/docs/workflows/dart_package.md
@@ -68,7 +68,7 @@ The Dart package workflow consists of the following steps:
 
 ### `check_ignore`
 
-**Optional** Allows ignoring lines from [coverage][coverage].
+**Optional** Allows ignoring lines from [coverage](https://pub.dev/packages/coverage).
 
 **Default** `false`
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

The "coverage" reference was missing a URL in `dart_package.md`. Added a reference to the [coverage package](https://pub.dev/packages/coverage) that has documentation about ignoring coverage:

> Ignore lines from coverage
// coverage:ignore-line to ignore one line.
// coverage:ignore-start and // coverage:ignore-end to ignore range of lines inclusive.
// coverage:ignore-file to ignore the whole file.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [X] 📝 Documentation
- [ ] 🗑️ Chore
