### PR TITLE
fix: runnable skipped tests in Dart packages

### DIFF
--- a/.github/workflows/dart_package.yml
+++ b/.github/workflows/dart_package.yml
@@ -104,7 +104,7 @@ jobs:
       - name: 🧪 Run Tests
         run: |
           dart pub global activate coverage 1.2.0
-          dart test -j ${{inputs.concurrency}} --coverage=coverage --platform=${{inputs.platform}} && dart pub global run coverage:format_coverage --lcov ${{(inputs.check_ignore && '--check-ignore') || ''}} --in=coverage --out=coverage/lcov.info --packages=.dart_tool/package_config.json --report-on=${{inputs.report_on}} ${{(inputs.run_skipped && '--run-skipped') || ''}}
+          dart test -j ${{inputs.concurrency}} --coverage=coverage --platform=${{inputs.platform}} ${{(inputs.run_skipped && '--run-skipped') || ''}} && dart pub global run coverage:format_coverage --lcov ${{(inputs.check_ignore && '--check-ignore') || ''}} --in=coverage --out=coverage/lcov.info --packages=.dart_tool/package_config.json --report-on=${{inputs.report_on}}
 
       - name: 📊 Check Code Coverage
         uses: VeryGoodOpenSource/very_good_coverage@v2


### PR DESCRIPTION
## Status

READY

## Description

Allow skipped tests to be runnable in workflows for Dart-only packages.

## Type of Change

- 🛠️ Bug fix (non-breaking change which fixes an issue)

## Related issues

- Closes #150 