### PR TITLE
fix: update mason creds example

### DIFF
--- a/site/docs/workflows/mason_publish.md
+++ b/site/docs/workflows/mason_publish.md
@@ -63,5 +63,5 @@ jobs:
       mason_version: '0.1.0-dev.50'
       working_directory: 'packages/my_mason_brick'
     secrets:
-      mason_credentials: secrets.MASON_CREDENTIALS
+      mason_credentials: ${{ secrets.MASON_CREDENTIALS }}
 ```


### PR DESCRIPTION
## Status

**READY**

## Description

Found this in the course of https://github.com/VeryGoodOpenSource/very_good_templates/pull/207. The secrets passed in need to be wrapped in the `${{ VAR }}` format to be passed in correctly. Updating the example to show this.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
