### PR TITLE
docs: update `coverage_excludes` example to something more useful

### DIFF
--- a/site/docs/workflows/flutter_package.md
+++ b/site/docs/workflows/flutter_package.md
@@ -121,7 +121,7 @@ jobs:
   build:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
-      coverage_excludes: '*.g.dart'
+      coverage_excludes: '**/*.g.dart'
       flutter_channel: 'stable'
       flutter_version: '3.24.0'
       working_directory: 'examples/my_flutter_package'


### PR DESCRIPTION
## Status

**READY**

## Description

While the current `*.g.dart` example is technically valid, a more useful example would be something like `**/**.g.dart`.

The current example only excludes generated files in the root directory where they're rarely placed.

The updated `**/*.g.dart` will cover generated files anywhere in the repository, which is probably a lot more helpful in real life scenarios.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
