### PR TITLE
docs: add copy-paste coverage exclude examples

### DIFF
--- a/site/docs/workflows/dart_package.md
+++ b/site/docs/workflows/dart_package.md
@@ -29,7 +29,13 @@ The Dart package workflow consists of the following steps:
 
 ### `coverage_excludes`
 
-**Optional** Space-separated list of globs to exclude files from the coverage report (e.g. '**/\*.g.dart **/gen/\*.dart').
+**Optional** Space-separated list of globs to exclude files from the coverage report (e.g. `'**/*.g.dart **/gen/*.dart'`).
+
+Use a single quoted string with each glob separated by spaces. For example, to exclude generated files and localization assets, copy/paste:
+
+```yaml
+coverage_excludes: 'lib/l10n/** **/*.g.dart **/*.freezed.dart'
+```
 
 **Default** `""`
 

--- a/site/docs/workflows/flutter_package.md
+++ b/site/docs/workflows/flutter_package.md
@@ -41,7 +41,13 @@ The Flutter package workflow consists of the following steps:
 
 ### `coverage_excludes`
 
-**Optional** Space-separated list of globs to exclude files from the coverage report (e.g. '**/\*.g.dart **/gen/\*.dart').
+**Optional** Space-separated list of globs to exclude files from the coverage report (e.g. `'**/*.g.dart **/gen/*.dart'`).
+
+Use a single quoted string with each glob separated by spaces. For example, to exclude generated files and localization assets, copy/paste:
+
+```yaml
+coverage_excludes: 'lib/l10n/** **/*.g.dart **/*.freezed.dart'
+```
 
 **Default** `""`
 


### PR DESCRIPTION
## Summary
- clarify that `coverage_excludes` expects a single quoted, space-separated string of globs
- add a copy-paste example covering `lib/l10n/**`, `**/*.g.dart`, and `**/*.freezed.dart`
- apply the same guidance to both Dart and Flutter workflow docs

Closes #327