### PR TITLE
feat(flutter_package): added post_setup_command in flutter_package workflow

### DIFF
--- a/.github/workflows/flutter_package.yml
+++ b/.github/workflows/flutter_package.yml
@@ -86,6 +86,10 @@ on:
         required: false
         type: string
         default: "."
+      post_setup_command:
+        required: false
+        type: string
+        default: ""
     secrets:
       ssh_key:
         required: false
@@ -126,6 +130,11 @@ jobs:
       - name: ⚙️ Run Setup
         if: "${{inputs.setup != ''}}"
         run: ${{inputs.setup}}
+
+      - name: 🛠️ Run post setup command
+        if: ${{ inputs.post_setup_command != '' }}
+        shell: bash
+        run: ${{ inputs.post_setup_command }}
 
       - name: ✨ Check Formatting
         run: dart format ${{inputs.format_line_length && format('--line-length {0}', inputs.format_line_length) || ''}} --set-exit-if-changed ${{inputs.format_directories}}


### PR DESCRIPTION
## Status

**READY**

## Description

Adds a new optional post_setup_command input to the flutter_package GitHub Actions workflow. This command runs after the existing setup step and before formatting, analysis, linting, and tests, allowing callers to perform extra specific preparation without modifying the shared workflow.

Example usage:

```yml
post_setup_command: |
  flutter pub run build_runner build --delete-conflicting-outputs
```

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
